### PR TITLE
Add DaysPastDue to search_loans output and offset pagination support

### DIFF
--- a/loanpro/loans.go
+++ b/loanpro/loans.go
@@ -1,124 +1,125 @@
 package loanpro
 
 import (
-	"encoding/json"
-	"fmt"
-	"os"
-)
+		"encoding/json"
+		"fmt"
+		"os"
+	)
 
 // GetLoan retrieves a loan by ID with expanded data
 func (c *Client) GetLoan(loanID string) (*Loan, error) {
-	// Use OData expand to include related data that provides loan amounts, status, and customer info
-	params := map[string]string{
-		"$expand": "LoanSettings,LoanSetup,Customers,StatusArchive",
-	}
+		// Use OData expand to include related data that provides loan amounts, status, and customer info
+		params := map[string]string{
+					"$expand": "LoanSettings,LoanSetup,Customers,StatusArchive",
+				}
 
-	body, err := c.makeRequest("/public/api/1/odata.svc/Loans("+loanID+")", params)
-	if err != nil {
-		return nil, err
-	}
+		body, err := c.makeRequest("/public/api/1/odata.svc/Loans("+loanID+")", params)
+		if err != nil {
+					return nil, err
+				}
 
-	var response ODataResponse
-	if err := json.Unmarshal(body, &response); err != nil {
-		fmt.Fprintf(os.Stderr, "[ERROR] Failed to parse GetLoan response: %v\nResponse body: %s\n", err, string(body))
-		return nil, fmt.Errorf("failed to parse response: %w", err)
-	}
+		var response ODataResponse
+		if err := json.Unmarshal(body, &response); err != nil {
+					fmt.Fprintf(os.Stderr, "[ERROR] Failed to parse GetLoan response: %v\nResponse body: %s\n", err, string(body))
+					return nil, fmt.Errorf("failed to parse response: %w", err)
+				}
 
-	loanData, err := json.Marshal(response.D)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "[ERROR] Failed to marshal loan data: %v\n", err)
-		return nil, fmt.Errorf("failed to marshal loan data: %w", err)
-	}
+		loanData, err := json.Marshal(response.D)
+		if err != nil {
+					fmt.Fprintf(os.Stderr, "[ERROR] Failed to marshal loan data: %v\n", err)
+					return nil, fmt.Errorf("failed to marshal loan data: %w", err)
+				}
 
-	var loan Loan
-	if err := json.Unmarshal(loanData, &loan); err != nil {
-		fmt.Fprintf(os.Stderr, "[ERROR] Failed to parse loan struct: %v\nLoan data: %s\n", err, string(loanData))
-		return nil, fmt.Errorf("failed to parse loan: %w", err)
-	}
+		var loan Loan
+		if err := json.Unmarshal(loanData, &loan); err != nil {
+					fmt.Fprintf(os.Stderr, "[ERROR] Failed to parse loan struct: %v\nLoan data: %s\n", err, string(loanData))
+					return nil, fmt.Errorf("failed to parse loan: %w", err)
+				}
 
-	return &loan, nil
+		return &loan, nil
 }
 
 // SearchLoans searches for loans using the search API
-func (c *Client) SearchLoans(searchTerm, status string, limit int) ([]Loan, error) {
-	// Build the search query according to LoanPro API format
-	searchBody := map[string]any{
-		"size": limit, // Use 'size' for pagination limit
-	}
+func (c *Client) SearchLoans(searchTerm, status string, limit, offset int) ([]Loan, error) {
+		// Build the search query according to LoanPro API format
+		searchBody := map[string]any{
+					"size": limit,
+					"from": offset,
+				}
 
-	// Build query conditions
-	var mustConditions []map[string]any
-	var shouldConditions []map[string]any
+		// Build query conditions
+		var mustConditions []map[string]any
+		var shouldConditions []map[string]any
 
-	// Add search term conditions if provided
-	if searchTerm != "" {
-		shouldConditions = append(shouldConditions,
-			map[string]any{
-				"query_string": map[string]any{
-					"query":            "*" + searchTerm + "*",
-					"fields":           []string{"displayId", "primaryCustomerName", "title"},
-					"default_operator": "and",
-				},
-			},
-			map[string]any{
-				"match": map[string]any{
-					"displayId": searchTerm,
-				},
-			},
-			map[string]any{
-				"match": map[string]any{
-					"primaryCustomerName": searchTerm,
-				},
-			},
-		)
-	}
+		// Add search term conditions if provided
+		if searchTerm != "" {
+					shouldConditions = append(shouldConditions,
+											  			map[string]any{
+																			"query_string": map[string]any{
+																									"query":            "*" + searchTerm + "*",
+																									"fields":           []string{"displayId", "primaryCustomerName", "title"},
+																									"default_operator": "and",
+																								},
+																		},
+											  			map[string]any{
+																			"match": map[string]any{
+																									"displayId": searchTerm,
+																								},
+																		},
+											  			map[string]any{
+																			"match": map[string]any{
+																									"primaryCustomerName": searchTerm,
+																								},
+																		},
+											  		)
+				}
 
-	// Add status filter if provided
-	if status != "" {
-		mustConditions = append(mustConditions, map[string]any{
-			"match": map[string]any{
-				"loanStatusText": status,
-			},
-		})
-	}
+		// Add status filter if provided
+		if status != "" {
+					mustConditions = append(mustConditions, map[string]any{
+									"match": map[string]any{
+														"loanStatusText": status,
+													},
+								})
+				}
 
-	// Build the final query
-	if len(mustConditions) > 0 || len(shouldConditions) > 0 {
-		boolQuery := map[string]any{}
+		// Build the final query
+		if len(mustConditions) > 0 || len(shouldConditions) > 0 {
+					boolQuery := map[string]any{}
 
-		if len(mustConditions) > 0 {
-			if len(mustConditions) == 1 {
-				boolQuery["must"] = mustConditions[0]
-			} else {
-				boolQuery["must"] = mustConditions
-			}
-		}
+					if len(mustConditions) > 0 {
+									if len(mustConditions) == 1 {
+														boolQuery["must"] = mustConditions[0]
+													} else {
+														boolQuery["must"] = mustConditions
+													}
+								}
 
-		if len(shouldConditions) > 0 {
-			boolQuery["should"] = shouldConditions
-			boolQuery["minimum_should_match"] = 1
-		}
+					if len(shouldConditions) > 0 {
+									boolQuery["should"] = shouldConditions
+									boolQuery["minimum_should_match"] = 1
+								}
 
-		searchBody["query"] = map[string]any{
-			"bool": boolQuery,
-		}
-	} else {
-		// If no filters, use match_all query
-		searchBody["query"] = map[string]any{
-			"match_all": map[string]any{},
-		}
-	}
+					searchBody["query"] = map[string]any{
+									"bool": boolQuery,
+								}
+				} else {
+					// If no filters, use match_all query
+					searchBody["query"] = map[string]any{
+									"match_all": map[string]any{},
+								}
+				}
 
-	body, err := c.makePostRequest("/public/api/1/Loans/Autopal.Search()", searchBody)
-	if err != nil {
-		return nil, err
-	}
+		body, err := c.makePostRequest("/public/api/1/Loans/Autopal.Search()", searchBody)
+		if err != nil {
+					return nil, err
+				}
 
-	var response SearchResponse
-	if err := json.Unmarshal(body, &response); err != nil {
-		fmt.Fprintf(os.Stderr, "[ERROR] Failed to parse SearchLoans response: %v\nResponse body: %s\n", err, string(body))
-		return nil, fmt.Errorf("failed to parse response: %w", err)
-	}
+		var response SearchResponse
+		if err := json.Unmarshal(body, &response); err != nil {
+					fmt.Fprintf(os.Stderr, "[ERROR] Failed to parse SearchLoans response: %v\nResponse body: %s\n", err, string(body))
+					return nil, fmt.Errorf("failed to parse response: %w", err)
+				}
 
-	return response.D.Results, nil
+		return response.D.Results, nil
 }

--- a/tools/search_loans.go
+++ b/tools/search_loans.go
@@ -4,56 +4,65 @@ import "fmt"
 
 // SearchLoansTool returns the search_loans tool definition
 func SearchLoansTool() Tool {
-	return Tool{
-		Name:        "search_loans",
-		Description: "Search loans with filters and search terms",
-		InputSchema: map[string]any{
-			"type": "object",
-			"properties": map[string]any{
-				"search_term": map[string]any{
-					"type":        "string",
-					"description": "Search term to match against customer name, display ID, or title",
-				},
-				"status": map[string]any{
-					"type":        "string",
-					"description": "Loan status filter",
-				},
-				"limit": map[string]any{
-					"type":        "number",
-					"description": "Maximum number of results",
-					"default":     10,
-				},
-			},
-		},
-	}
+		return Tool{
+					Name:        "search_loans",
+					Description: "Search loans with filters and search terms",
+					InputSchema: map[string]any{
+									"type": "object",
+									"properties": map[string]any{
+														"search_term": map[string]any{
+																				"type":        "string",
+																				"description": "Search term to match against customer name, display ID, or title",
+																			},
+														"status": map[string]any{
+																				"type":        "string",
+																				"description": "Loan status filter",
+																			},
+														"limit": map[string]any{
+																				"type":        "number",
+																				"description": "Maximum number of results",
+																				"default":     10,
+																			},
+														"offset": map[string]any{
+																				"type":        "number",
+																				"description": "Number of results to skip for pagination",
+																				"default":     0,
+																			},
+													},
+								},
+				}
 }
 
 // executeSearchLoans handles the search_loans tool execution
 func (m *Manager) executeSearchLoans(arguments map[string]any) MCPResponse {
-	searchTerm := ""
-	if term, ok := arguments["search_term"].(string); ok {
-		searchTerm = term
-	}
-	status := ""
-	if s, ok := arguments["status"].(string); ok {
-		status = s
-	}
-	limit := 10
-	if l, ok := arguments["limit"].(float64); ok {
-		limit = int(l)
-	}
+		searchTerm := ""
+		if term, ok := arguments["search_term"].(string); ok {
+					searchTerm = term
+				}
+		status := ""
+		if s, ok := arguments["status"].(string); ok {
+					status = s
+				}
+		limit := 10
+		if l, ok := arguments["limit"].(float64); ok {
+					limit = int(l)
+				}
+		offset := 0
+		if o, ok := arguments["offset"].(float64); ok {
+					offset = int(o)
+				}
 
-	loans, err := m.client.SearchLoans(searchTerm, status, limit)
-	if err != nil {
-		LogError("search_loans", err, fmt.Sprintf("with term='%s', status='%s', limit=%d", searchTerm, status, limit))
-		return CreateErrorResponse(-1, err.Error(), nil)
-	}
+		loans, err := m.client.SearchLoans(searchTerm, status, limit, offset)
+		if err != nil {
+					LogError("search_loans", err, fmt.Sprintf("with term='%s', status='%s', limit=%d, offset=%d", searchTerm, status, limit, offset))
+					return CreateErrorResponse(-1, err.Error(), nil)
+				}
 
-	text := "Loans:\n"
-	for _, loan := range loans {
-		text += fmt.Sprintf("- ID: %s, Display ID: %s, Customer: %s, Status: %s, Balance: $%s\n",
-			loan.GetID(), loan.GetDisplayID(), loan.GetPrimaryCustomerName(), loan.GetLoanStatus(), loan.GetPrincipalBalance())
-	}
+		text := "Loans:\n"
+		for _, loan := range loans {
+					text += fmt.Sprintf("- ID: %s, Display ID: %s, Customer: %s, Status: %s, Balance: $%s, Days Past Due: %s\n",
+													loan.GetID(), loan.GetDisplayID(), loan.GetPrimaryCustomerName(), loan.GetLoanStatus(), loan.GetPrincipalBalance(), loan.DaysPastDue.String())
+				}
 
-	return CreateSuccessResponse(text, nil)
+		return CreateSuccessResponse(text, nil)
 }


### PR DESCRIPTION
## Changes

**`tools/search_loans.go`**
- Added `DaysPastDue` field to the formatted output of each loan result
- - Added `offset` parameter to the tool input schema (default: 0)
- - Passes `offset` through to `SearchLoans`
**`loanpro/loans.go`**
- Updated `SearchLoans` function signature to accept `offset int`
- - Added `"from": offset` to the Elasticsearch search body for pagination
## Why
The weekly past-due loan task needs `DaysPastDue` to identify overdue loans directly from search results, and pagination support to retrieve all open loans beyond the first 50.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Loan search functionality now supports pagination with configurable offset, enabling users to efficiently navigate through larger result sets
  * Loan search results now include Days Past Due information alongside existing loan details

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MiloCreditPlatform/loanpro-mcp-server/pull/8)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->