### PR TITLE
add DaysPastDue and offset pagination to search_loans

### DIFF
--- a/loanpro/loans.go
+++ b/loanpro/loans.go
@@ -40,10 +40,11 @@ func (c *Client) GetLoan(loanID string) (*Loan, error) {
 }
 
 // SearchLoans searches for loans using the search API
-func (c *Client) SearchLoans(searchTerm, status string, limit int) ([]Loan, error) {
+func (c *Client) SearchLoans(searchTerm, status string, limit, offset int) ([]Loan, error) {
 	// Build the search query according to LoanPro API format
 	searchBody := map[string]any{
-		"size": limit, // Use 'size' for pagination limit
+		"size": limit,
+		"from": offset,
 	}
 
 	// Build query conditions

--- a/main.go
+++ b/main.go
@@ -89,8 +89,8 @@ func (ca *ClientAdapter) GetLoan(id string) (tools.Loan, error) {
 	return loan, nil
 }
 
-func (ca *ClientAdapter) SearchLoans(searchTerm, status string, limit int) ([]tools.Loan, error) {
-	loans, err := ca.client.SearchLoans(searchTerm, status, limit)
+func (ca *ClientAdapter) SearchLoans(searchTerm, status string, limit, offset int) ([]tools.Loan, error) {
+	loans, err := ca.client.SearchLoans(searchTerm, status, limit, offset)
 	if err != nil {
 		return nil, err
 	}

--- a/tools/manager_test.go
+++ b/tools/manager_test.go
@@ -29,6 +29,7 @@ func (m MockLoan) GetPrimaryCustomerName() string { return m.primaryCustomerName
 func (m MockLoan) GetLoanStatus() string          { return m.loanStatus }
 func (m MockLoan) GetPrincipalBalance() string    { return m.principalBalance }
 func (m MockLoan) GetPayoffAmount() string        { return m.payoffAmount }
+func (m MockLoan) GetDaysPastDue() string         { return "0" }
 
 // MockCustomer implements the Customer interface
 type MockCustomer struct {
@@ -111,7 +112,7 @@ func (m *MockLoanProClient) GetLoan(id string) (Loan, error) {
 	return nil, nil
 }
 
-func (m *MockLoanProClient) SearchLoans(searchTerm, status string, limit int) ([]Loan, error) {
+func (m *MockLoanProClient) SearchLoans(searchTerm, status string, limit, offset int) ([]Loan, error) {
 	var results []Loan
 	count := 0
 	for _, loan := range m.loans {

--- a/tools/search_loans.go
+++ b/tools/search_loans.go
@@ -23,6 +23,11 @@ func SearchLoansTool() Tool {
 					"description": "Maximum number of results",
 					"default":     10,
 				},
+				"offset": map[string]any{
+					"type":        "number",
+					"description": "Number of results to skip for pagination",
+					"default":     0,
+				},
 			},
 		},
 	}
@@ -42,8 +47,12 @@ func (m *Manager) executeSearchLoans(arguments map[string]any) MCPResponse {
 	if l, ok := arguments["limit"].(float64); ok {
 		limit = int(l)
 	}
+	offset := 0
+	if o, ok := arguments["offset"].(float64); ok {
+		offset = int(o)
+	}
 
-	loans, err := m.client.SearchLoans(searchTerm, status, limit)
+	loans, err := m.client.SearchLoans(searchTerm, status, limit, offset)
 	if err != nil {
 		LogError("search_loans", err, fmt.Sprintf("with term='%s', status='%s', limit=%d", searchTerm, status, limit))
 		return CreateErrorResponse(-1, err.Error(), nil)
@@ -51,8 +60,8 @@ func (m *Manager) executeSearchLoans(arguments map[string]any) MCPResponse {
 
 	text := "Loans:\n"
 	for _, loan := range loans {
-		text += fmt.Sprintf("- ID: %s, Display ID: %s, Customer: %s, Status: %s, Balance: $%s\n",
-			loan.GetID(), loan.GetDisplayID(), loan.GetPrimaryCustomerName(), loan.GetLoanStatus(), loan.GetPrincipalBalance())
+		text += fmt.Sprintf("- ID: %s, Display ID: %s, Customer: %s, Status: %s, Balance: $%s, Days Past Due: %s\n",
+			loan.GetID(), loan.GetDisplayID(), loan.GetPrimaryCustomerName(), loan.GetLoanStatus(), loan.GetPrincipalBalance(), loan.GetDaysPastDue())
 	}
 
 	return CreateSuccessResponse(text, nil)

--- a/tools/types.go
+++ b/tools/types.go
@@ -36,7 +36,7 @@ type TransactionOptions struct {
 // LoanProClient interface for dependency injection
 type LoanProClient interface {
 	GetLoan(id string) (Loan, error)
-	SearchLoans(searchTerm, status string, limit int) ([]Loan, error)
+	SearchLoans(searchTerm, status string, limit, offset int) ([]Loan, error)
 	GetCustomer(id string) (Customer, error)
 	SearchCustomers(searchTerm string, limit int) ([]Customer, error)
 	GetLoanPayments(loanID string) ([]Payment, error)
@@ -52,6 +52,7 @@ type Loan interface {
 	GetLoanStatus() string
 	GetPrincipalBalance() string
 	GetPayoffAmount() string
+	GetDaysPastDue() string
 }
 
 // Customer represents customer data - simplified interface for tools


### PR DESCRIPTION
- Added offset parameter to SearchLoans across the interface, implementation, adapter, and mock for pagination support                                                              - Added "from": offset to the Elasticsearch search body in loanpro/loans.go
- Added GetDaysPastDue() string to the tools.Loan interface and exposed it in the search_loans output
- Added "offset" to the search_loans tool's InputSchema so MCP clients can paginate results
