### PR TITLE
add get_past_due_loans tool

### DIFF
--- a/loanpro/loans.go
+++ b/loanpro/loans.go
@@ -126,7 +126,10 @@ func (c *Client) SearchLoans(searchTerm, status string, limit, offset int) ([]Lo
 
 const maxPastDueLimit = 200
 
-// GetPastDueLoans retrieves loans past due by more than minDaysPastDue days using OData filtering
+// GetPastDueLoans retrieves open loans with more than minDaysPastDue days past due
+// using the Elasticsearch search endpoint with a range query, which supports daysPastDue
+// filtering. The OData endpoint cannot filter on daysPastDue as it is not a direct
+// Loan entity property.
 func (c *Client) GetPastDueLoans(minDaysPastDue, limit, offset int) ([]Loan, error) {
 	if minDaysPastDue < 0 {
 		return nil, fmt.Errorf("minDaysPastDue must be non-negative")
@@ -141,19 +144,40 @@ func (c *Client) GetPastDueLoans(minDaysPastDue, limit, offset int) ([]Loan, err
 		limit = maxPastDueLimit
 	}
 
-	params := map[string]string{
-		"$filter": fmt.Sprintf("DaysPastDue gt %d and loanStatusText eq 'Open'", minDaysPastDue),
-		"$expand": "Customers",
-		"$top":    fmt.Sprintf("%d", limit),
-		"$skip":   fmt.Sprintf("%d", offset),
+	searchBody := map[string]any{
+		"size": limit,
+		"query": map[string]any{
+			"bool": map[string]any{
+				"must": []map[string]any{
+					{
+						"range": map[string]any{
+							"daysPastDue": map[string]any{
+								"gt": minDaysPastDue,
+							},
+						},
+					},
+					{
+						"match": map[string]any{
+							"loanStatusText": "Open",
+						},
+					},
+				},
+			},
+		},
+		"sort": []map[string]any{
+			{"daysPastDue": map[string]any{"order": "desc"}},
+		},
+	}
+	if offset > 0 {
+		searchBody["from"] = offset
 	}
 
-	body, err := c.makeRequest("/public/api/1/odata.svc/Loans", params)
+	body, err := c.makePostRequest("/public/api/1/Loans/Autopal.Search()", searchBody)
 	if err != nil {
 		return nil, err
 	}
 
-	var response ODataLoansResponse
+	var response SearchResponse
 	if err := json.Unmarshal(body, &response); err != nil {
 		fmt.Fprintf(os.Stderr, "[ERROR] Failed to parse GetPastDueLoans response: %v\nResponse body: %s\n", err, string(body))
 		return nil, fmt.Errorf("failed to parse response: %w", err)

--- a/loanpro/loans.go
+++ b/loanpro/loans.go
@@ -123,3 +123,26 @@ func (c *Client) SearchLoans(searchTerm, status string, limit, offset int) ([]Lo
 
 	return response.D.Results, nil
 }
+
+// GetPastDueLoans retrieves loans past due by at least minDaysPastDue days using OData filtering
+func (c *Client) GetPastDueLoans(minDaysPastDue, limit, offset int) ([]Loan, error) {
+	params := map[string]string{
+		"$filter": fmt.Sprintf("DaysPastDue gt %d and loanStatusText eq 'Open'", minDaysPastDue),
+		"$expand": "Customers",
+		"$top":    fmt.Sprintf("%d", limit),
+		"$skip":   fmt.Sprintf("%d", offset),
+	}
+
+	body, err := c.makeRequest("/public/api/1/odata.svc/Loans", params)
+	if err != nil {
+		return nil, err
+	}
+
+	var response ODataLoansResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		fmt.Fprintf(os.Stderr, "[ERROR] Failed to parse GetPastDueLoans response: %v\nResponse body: %s\n", err, string(body))
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	return response.D.Results, nil
+}

--- a/loanpro/loans.go
+++ b/loanpro/loans.go
@@ -124,8 +124,23 @@ func (c *Client) SearchLoans(searchTerm, status string, limit, offset int) ([]Lo
 	return response.D.Results, nil
 }
 
-// GetPastDueLoans retrieves loans past due by at least minDaysPastDue days using OData filtering
+const maxPastDueLimit = 200
+
+// GetPastDueLoans retrieves loans past due by more than minDaysPastDue days using OData filtering
 func (c *Client) GetPastDueLoans(minDaysPastDue, limit, offset int) ([]Loan, error) {
+	if minDaysPastDue < 0 {
+		return nil, fmt.Errorf("minDaysPastDue must be non-negative")
+	}
+	if limit <= 0 {
+		return nil, fmt.Errorf("limit must be positive")
+	}
+	if offset < 0 {
+		return nil, fmt.Errorf("offset must be non-negative")
+	}
+	if limit > maxPastDueLimit {
+		limit = maxPastDueLimit
+	}
+
 	params := map[string]string{
 		"$filter": fmt.Sprintf("DaysPastDue gt %d and loanStatusText eq 'Open'", minDaysPastDue),
 		"$expand": "Customers",

--- a/loanpro/types.go
+++ b/loanpro/types.go
@@ -172,6 +172,12 @@ type ODataResponse struct {
 	D any `json:"d"`
 }
 
+type ODataLoansResponse struct {
+	D struct {
+		Results []Loan `json:"results"`
+	} `json:"d"`
+}
+
 type SearchResponse struct {
 	D struct {
 		Results []Loan `json:"results"`

--- a/main.go
+++ b/main.go
@@ -140,6 +140,19 @@ func (ca *ClientAdapter) GetLoanTransactions(loanID string) ([]tools.Transaction
 	return ca.GetLoanTransactionsWithOptions(loanID, nil)
 }
 
+func (ca *ClientAdapter) GetPastDueLoans(minDaysPastDue, limit, offset int) ([]tools.Loan, error) {
+	loans, err := ca.client.GetPastDueLoans(minDaysPastDue, limit, offset)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make([]tools.Loan, len(loans))
+	for i, loan := range loans {
+		result[i] = &loan
+	}
+	return result, nil
+}
+
 func (ca *ClientAdapter) GetLoanTransactionsWithOptions(loanID string, opts *tools.TransactionOptions) ([]tools.Transaction, error) {
 	// Convert tools.TransactionOptions to loanpro.TransactionOptions
 	var loanProOpts *loanpro.TransactionOptions

--- a/tools/get_past_due_loans.go
+++ b/tools/get_past_due_loans.go
@@ -1,0 +1,65 @@
+package tools
+
+import "fmt"
+
+// GetPastDueLoansTool returns the get_past_due_loans tool definition
+func GetPastDueLoansTool() Tool {
+	return Tool{
+		Name:        "get_past_due_loans",
+		Description: "Get loans that are past due by at least a given number of days, queried directly from the OData API for complete coverage",
+		InputSchema: map[string]any{
+			"type": "object",
+			"properties": map[string]any{
+				"min_days_past_due": map[string]any{
+					"type":        "number",
+					"description": "Minimum number of days past due (inclusive threshold)",
+					"default":     5,
+				},
+				"limit": map[string]any{
+					"type":        "number",
+					"description": "Maximum number of results",
+					"default":     50,
+				},
+				"offset": map[string]any{
+					"type":        "number",
+					"description": "Number of results to skip for pagination",
+					"default":     0,
+				},
+			},
+		},
+	}
+}
+
+// executeGetPastDueLoans handles the get_past_due_loans tool execution
+func (m *Manager) executeGetPastDueLoans(arguments map[string]any) MCPResponse {
+	minDaysPastDue := 5
+	if v, ok := arguments["min_days_past_due"].(float64); ok {
+		minDaysPastDue = int(v)
+	}
+	limit := 50
+	if v, ok := arguments["limit"].(float64); ok {
+		limit = int(v)
+	}
+	offset := 0
+	if v, ok := arguments["offset"].(float64); ok {
+		offset = int(v)
+	}
+
+	loans, err := m.client.GetPastDueLoans(minDaysPastDue, limit, offset)
+	if err != nil {
+		LogError("get_past_due_loans", err, fmt.Sprintf("with min_days_past_due=%d, limit=%d, offset=%d", minDaysPastDue, limit, offset))
+		return CreateErrorResponse(-1, err.Error(), nil)
+	}
+
+	if len(loans) == 0 {
+		return CreateSuccessResponse(fmt.Sprintf("No loans found with more than %d days past due.", minDaysPastDue), nil)
+	}
+
+	text := fmt.Sprintf("Past Due Loans (>%d days):\n", minDaysPastDue)
+	for _, loan := range loans {
+		text += fmt.Sprintf("- ID: %s, Display ID: %s, Customer: %s, Days Past Due: %s, Balance: $%s\n",
+			loan.GetID(), loan.GetDisplayID(), loan.GetPrimaryCustomerName(), loan.GetDaysPastDue(), loan.GetPrincipalBalance())
+	}
+
+	return CreateSuccessResponse(text, nil)
+}

--- a/tools/get_past_due_loans.go
+++ b/tools/get_past_due_loans.go
@@ -12,7 +12,7 @@ func GetPastDueLoansTool() Tool {
 			"properties": map[string]any{
 				"min_days_past_due": map[string]any{
 					"type":        "number",
-					"description": "Minimum number of days past due (inclusive threshold)",
+					"description": "Returns loans with MORE than this many days past due (exclusive threshold)",
 					"default":     5,
 				},
 				"limit": map[string]any{
@@ -43,6 +43,16 @@ func (m *Manager) executeGetPastDueLoans(arguments map[string]any) MCPResponse {
 	offset := 0
 	if v, ok := arguments["offset"].(float64); ok {
 		offset = int(v)
+	}
+
+	if minDaysPastDue < 0 {
+		return CreateErrorResponse(-1, "min_days_past_due must be non-negative", nil)
+	}
+	if limit <= 0 {
+		return CreateErrorResponse(-1, "limit must be positive", nil)
+	}
+	if offset < 0 {
+		return CreateErrorResponse(-1, "offset must be non-negative", nil)
 	}
 
 	loans, err := m.client.GetPastDueLoans(minDaysPastDue, limit, offset)

--- a/tools/get_past_due_loans.go
+++ b/tools/get_past_due_loans.go
@@ -6,7 +6,7 @@ import "fmt"
 func GetPastDueLoansTool() Tool {
 	return Tool{
 		Name:        "get_past_due_loans",
-		Description: "Get loans that are past due by at least a given number of days, queried directly from the OData API for complete coverage",
+		Description: "Get open loans with more than a given number of days past due, sorted by days past due descending",
 		InputSchema: map[string]any{
 			"type": "object",
 			"properties": map[string]any{

--- a/tools/manager.go
+++ b/tools/manager.go
@@ -21,6 +21,7 @@ func (m *Manager) GetAllTools() []Tool {
 		SearchCustomersTool(),
 		GetLoanPaymentsTool(),
 		GetLoanTransactionsTool(),
+		GetPastDueLoansTool(),
 	}
 }
 
@@ -39,6 +40,8 @@ func (m *Manager) ExecuteTool(toolName string, arguments map[string]any) MCPResp
 		return m.executeGetLoanPayments(arguments)
 	case "get_loan_transactions":
 		return m.executeGetLoanTransactions(arguments)
+	case "get_past_due_loans":
+		return m.executeGetPastDueLoans(arguments)
 	default:
 		return MCPResponse{
 			JSONRPC: "2.0",

--- a/tools/manager_test.go
+++ b/tools/manager_test.go
@@ -166,6 +166,19 @@ func (m *MockLoanProClient) GetLoanTransactions(loanID string) ([]Transaction, e
 	return m.GetLoanTransactionsWithOptions(loanID, nil)
 }
 
+func (m *MockLoanProClient) GetPastDueLoans(minDaysPastDue, limit, offset int) ([]Loan, error) {
+	var results []Loan
+	count := 0
+	for _, loan := range m.loans {
+		if count >= limit {
+			break
+		}
+		results = append(results, loan)
+		count++
+	}
+	return results, nil
+}
+
 func (m *MockLoanProClient) GetLoanTransactionsWithOptions(loanID string, opts *TransactionOptions) ([]Transaction, error) {
 	if transactions, exists := m.transactions[loanID]; exists {
 		var result []Transaction
@@ -260,7 +273,7 @@ func TestManager_GetAllTools(t *testing.T) {
 
 	tools := manager.GetAllTools()
 
-	expectedTools := []string{"get_loan", "search_loans", "get_customer", "search_customers", "get_loan_payments", "get_loan_transactions"}
+	expectedTools := []string{"get_loan", "search_loans", "get_customer", "search_customers", "get_loan_payments", "get_loan_transactions", "get_past_due_loans"}
 
 	if len(tools) != len(expectedTools) {
 		t.Errorf("Expected %d tools, got %d", len(expectedTools), len(tools))
@@ -749,4 +762,63 @@ func TestManager_ExecuteTool_GetLoanTransactions_WithPagination(t *testing.T) {
 			t.Errorf("Expected 'No transactions found' when offset > available records, got: %s", text)
 		}
 	})
+}
+
+func TestManager_ExecuteTool_GetPastDueLoans(t *testing.T) {
+	mockClient := createMockClient()
+	manager := NewManager(mockClient)
+
+	arguments := map[string]any{
+		"min_days_past_due": float64(5),
+		"limit":             float64(10),
+	}
+
+	response := manager.ExecuteTool("get_past_due_loans", arguments)
+
+	if response.JSONRPC != "2.0" {
+		t.Errorf("Expected JSONRPC 2.0, got %s", response.JSONRPC)
+	}
+
+	if response.Error != nil {
+		t.Errorf("Expected no error, got %v", response.Error)
+	}
+
+	if response.Result == nil {
+		t.Fatal("Expected result, got nil")
+	}
+
+	result, ok := response.Result.(map[string]any)
+	if !ok {
+		t.Fatal("Expected result to be map[string]any")
+	}
+
+	content, ok := result["content"].([]map[string]any)
+	if !ok {
+		t.Fatal("Expected content to be []map[string]any")
+	}
+
+	text, ok := content[0]["text"].(string)
+	if !ok {
+		t.Fatal("Expected text to be string")
+	}
+
+	if !strings.Contains(text, "Days Past Due") {
+		t.Errorf("Expected response to contain 'Days Past Due', got: %s", text)
+	}
+}
+
+func TestManager_ExecuteTool_GetPastDueLoans_Defaults(t *testing.T) {
+	mockClient := createMockClient()
+	manager := NewManager(mockClient)
+
+	// Call with no arguments to exercise defaults
+	response := manager.ExecuteTool("get_past_due_loans", map[string]any{})
+
+	if response.JSONRPC != "2.0" {
+		t.Errorf("Expected JSONRPC 2.0, got %s", response.JSONRPC)
+	}
+
+	if response.Error != nil {
+		t.Errorf("Expected no error, got %v", response.Error)
+	}
 }

--- a/tools/types.go
+++ b/tools/types.go
@@ -42,6 +42,7 @@ type LoanProClient interface {
 	GetLoanPayments(loanID string) ([]Payment, error)
 	GetLoanTransactions(loanID string) ([]Transaction, error)
 	GetLoanTransactionsWithOptions(loanID string, opts *TransactionOptions) ([]Transaction, error)
+	GetPastDueLoans(minDaysPastDue, limit, offset int) ([]Loan, error)
 }
 
 // Loan represents loan data - simplified interface for tools


### PR DESCRIPTION
## Summary
- New `get_past_due_loans` tool returns open loans sorted by days past due (descending)
- Uses the Elasticsearch `Autopal.Search()` endpoint with a `range` query on `daysPastDue` — OData was not viable since `daysPastDue` is not a direct Loan entity property and cannot be used in `$filter`
- Supports `min_days_past_due` (default 5, exclusive), `limit` (default 50, max 200), and `offset` (default 0) for pagination

## Changes
- `tools/get_past_due_loans.go` — tool definition and execution logic (new file)
- `loanpro/loans.go` — `GetPastDueLoans` method using Elasticsearch range query with input validation and 200-record cap
- `loanpro/types.go` — `ODataLoansResponse` struct (added during initial OData attempt, retained for future use)
- `tools/manager.go` — tool registered in `GetAllTools` and `ExecuteTool`
- `tools/types.go` — `GetPastDueLoans` added to `LoanProClient` interface
- `main.go` — `GetPastDueLoans` adapter on `*ClientAdapter`
- `tools/manager_test.go` — mock implementation and two unit tests

## Test plan
- [x] `go test ./...` — all 4 packages pass
- [x] Live test: `min_days_past_due=5, limit=10` returns 10 loans with correct DPD values
- [x] Live test: `min_days_past_due=30, limit=5` returns correct subset sorted by DPD desc
- [x] Live test: `offset=5` picks up exactly where `offset=0` left off — no overlap
- [x] Test validation guards: negative `min_days_past_due`, zero `limit`, negative `offset`

🤖 Generated with [Claude Code](https://claude.com/claude-code)