### PR TITLE
fix: populate LoanSetup in get_past_due_loans; sort ascending by DPD

### DIFF
--- a/loanpro/loans.go
+++ b/loanpro/loans.go
@@ -3,6 +3,7 @@ package loanpro
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 )
 
@@ -126,10 +127,10 @@ func (c *Client) SearchLoans(searchTerm, status string, limit, offset int) ([]Lo
 
 const maxPastDueLimit = 200
 
-// GetPastDueLoans retrieves open loans with more than minDaysPastDue days past due
-// using the Elasticsearch search endpoint with a range query, which supports daysPastDue
-// filtering. The OData endpoint cannot filter on daysPastDue as it is not a direct
-// Loan entity property.
+// GetPastDueLoans retrieves open loans with more than minDaysPastDue days past due.
+// Elasticsearch is used to filter by daysPastDue (not available as an OData filter),
+// then each matched loan is fetched individually via OData with $expand so that
+// LoanSetup and other nested entities are fully populated.
 func (c *Client) GetPastDueLoans(minDaysPastDue, limit, offset int) ([]Loan, error) {
 	if minDaysPastDue < 0 {
 		return nil, fmt.Errorf("minDaysPastDue must be non-negative")
@@ -165,7 +166,7 @@ func (c *Client) GetPastDueLoans(minDaysPastDue, limit, offset int) ([]Loan, err
 			},
 		},
 		"sort": []map[string]any{
-			{"daysPastDue": map[string]any{"order": "desc"}},
+			{"daysPastDue": map[string]any{"order": "asc"}},
 		},
 	}
 	if offset > 0 {
@@ -177,11 +178,23 @@ func (c *Client) GetPastDueLoans(minDaysPastDue, limit, offset int) ([]Loan, err
 		return nil, err
 	}
 
-	var response SearchResponse
-	if err := json.Unmarshal(body, &response); err != nil {
+	var searchResp SearchResponse
+	if err := json.Unmarshal(body, &searchResp); err != nil {
 		fmt.Fprintf(os.Stderr, "[ERROR] Failed to parse GetPastDueLoans response: %v\nResponse body: %s\n", err, string(body))
 		return nil, fmt.Errorf("failed to parse response: %w", err)
 	}
 
-	return response.D.Results, nil
+	// Fetch each loan individually via OData so LoanSetup (and other nested
+	// entities) are fully expanded — the search index does not include them.
+	loans := make([]Loan, 0, len(searchResp.D.Results))
+	for _, result := range searchResp.D.Results {
+		loan, err := c.GetLoan(string(result.ID))
+		if err != nil {
+			slog.Warn("GetPastDueLoans: skipping loan, failed to fetch details", "id", result.ID, "error", err)
+			continue
+		}
+		loans = append(loans, *loan)
+	}
+
+	return loans, nil
 }

--- a/loanpro/loans.go
+++ b/loanpro/loans.go
@@ -128,6 +128,7 @@ func (c *Client) SearchLoans(searchTerm, status string, limit, offset int) ([]Lo
 }
 
 const maxPastDueLimit = 200
+const odataBatchSize = 50
 
 // GetPastDueLoans retrieves open loans with more than minDaysPastDue days past due.
 // Elasticsearch is used to filter by daysPastDue (not available as an OData filter),
@@ -190,39 +191,59 @@ func (c *Client) GetPastDueLoans(minDaysPastDue, limit, offset int) ([]Loan, err
 		return []Loan{}, nil
 	}
 
-	// Build a single OData request for all matched IDs so LoanSetup and other
-	// nested entities are fully expanded in one round trip.
-	filterParts := make([]string, 0, len(searchResp.D.Results))
-	for _, result := range searchResp.D.Results {
-		filterParts = append(filterParts, fmt.Sprintf("id eq %s", string(result.ID)))
+	// Validate IDs and chunk into batches to stay within OData URL length limits.
+	// Each batch gets its own $filter=id eq X or id eq Y request with $expand.
+	results := searchResp.D.Results
+	loans := make([]Loan, 0, len(results))
+	for start := 0; start < len(results); start += odataBatchSize {
+		end := start + odataBatchSize
+		if end > len(results) {
+			end = len(results)
+		}
+
+		filterParts := make([]string, 0, end-start)
+		for _, result := range results[start:end] {
+			idStr := strings.TrimSpace(string(result.ID))
+			if _, err := strconv.Atoi(idStr); err != nil {
+				return nil, fmt.Errorf("invalid loan id in search response: %q", idStr)
+			}
+			filterParts = append(filterParts, "id eq "+idStr)
+		}
+
+		params := map[string]string{
+			"$filter": strings.Join(filterParts, " or "),
+			"$expand": "LoanSettings,LoanSetup,Customers,StatusArchive",
+			"$top":    strconv.Itoa(end - start),
+		}
+
+		odataBody, err := c.makeRequest("/public/api/1/odata.svc/Loans", params)
+		if err != nil {
+			return nil, err
+		}
+
+		var batch ODataLoansResponse
+		if err := json.Unmarshal(odataBody, &batch); err != nil {
+			fmt.Fprintf(os.Stderr, "[ERROR] Failed to parse GetPastDueLoans OData response: %v\nResponse body: %s\n", err, string(odataBody))
+			return nil, fmt.Errorf("failed to parse OData response: %w", err)
+		}
+		loans = append(loans, batch.D.Results...)
 	}
 
-	params := map[string]string{
-		"$filter": strings.Join(filterParts, " or "),
-		"$expand": "LoanSettings,LoanSetup,Customers,StatusArchive",
-		"$top":    strconv.Itoa(len(searchResp.D.Results)),
-	}
-
-	odataBody, err := c.makeRequest("/public/api/1/odata.svc/Loans", params)
-	if err != nil {
-		return nil, err
-	}
-
-	var odataResp ODataLoansResponse
-	if err := json.Unmarshal(odataBody, &odataResp); err != nil {
-		fmt.Fprintf(os.Stderr, "[ERROR] Failed to parse GetPastDueLoans OData response: %v\nResponse body: %s\n", err, string(odataBody))
-		return nil, fmt.Errorf("failed to parse OData response: %w", err)
-	}
-
-	loans := odataResp.D.Results
 	if len(loans) == 0 {
-		return nil, fmt.Errorf("failed to fetch loan details: Elasticsearch returned %d matches but OData returned no results", len(searchResp.D.Results))
+		return nil, fmt.Errorf("failed to fetch loan details: Elasticsearch returned %d matches but OData returned no results", len(results))
 	}
 
 	// OData doesn't preserve Elasticsearch sort order; re-sort by daysPastDue ascending.
+	// Loans with unparseable daysPastDue are pushed to the end.
 	sort.Slice(loans, func(i, j int) bool {
-		dpdI, _ := strconv.Atoi(loans[i].GetDaysPastDue())
-		dpdJ, _ := strconv.Atoi(loans[j].GetDaysPastDue())
+		dpdI, errI := strconv.Atoi(loans[i].GetDaysPastDue())
+		dpdJ, errJ := strconv.Atoi(loans[j].GetDaysPastDue())
+		if errI != nil {
+			dpdI = int(^uint(0) >> 1)
+		}
+		if errJ != nil {
+			dpdJ = int(^uint(0) >> 1)
+		}
 		return dpdI < dpdJ
 	})
 

--- a/loanpro/loans.go
+++ b/loanpro/loans.go
@@ -3,8 +3,10 @@ package loanpro
 import (
 	"encoding/json"
 	"fmt"
-	"log/slog"
 	"os"
+	"sort"
+	"strconv"
+	"strings"
 )
 
 // GetLoan retrieves a loan by ID with expanded data
@@ -184,17 +186,42 @@ func (c *Client) GetPastDueLoans(minDaysPastDue, limit, offset int) ([]Loan, err
 		return nil, fmt.Errorf("failed to parse response: %w", err)
 	}
 
-	// Fetch each loan individually via OData so LoanSetup (and other nested
-	// entities) are fully expanded — the search index does not include them.
-	loans := make([]Loan, 0, len(searchResp.D.Results))
-	for _, result := range searchResp.D.Results {
-		loan, err := c.GetLoan(string(result.ID))
-		if err != nil {
-			slog.Warn("GetPastDueLoans: skipping loan, failed to fetch details", "id", result.ID, "error", err)
-			continue
-		}
-		loans = append(loans, *loan)
+	if len(searchResp.D.Results) == 0 {
+		return []Loan{}, nil
 	}
+
+	// Build a single OData request for all matched IDs so LoanSetup and other
+	// nested entities are fully expanded in one round trip.
+	filterParts := make([]string, 0, len(searchResp.D.Results))
+	for _, result := range searchResp.D.Results {
+		filterParts = append(filterParts, fmt.Sprintf("id eq %s", string(result.ID)))
+	}
+
+	params := map[string]string{
+		"$filter": strings.Join(filterParts, " or "),
+		"$expand": "LoanSettings,LoanSetup,Customers,StatusArchive",
+		"$top":    strconv.Itoa(len(searchResp.D.Results)),
+	}
+
+	odataBody, err := c.makeRequest("/public/api/1/odata.svc/Loans", params)
+	if err != nil {
+		return nil, err
+	}
+
+	var odataResp ODataLoansResponse
+	if err := json.Unmarshal(odataBody, &odataResp); err != nil {
+		fmt.Fprintf(os.Stderr, "[ERROR] Failed to parse GetPastDueLoans OData response: %v\nResponse body: %s\n", err, string(odataBody))
+		return nil, fmt.Errorf("failed to parse OData response: %w", err)
+	}
+
+	loans := odataResp.D.Results
+
+	// OData doesn't preserve Elasticsearch sort order; re-sort by daysPastDue ascending.
+	sort.Slice(loans, func(i, j int) bool {
+		dpdI, _ := strconv.Atoi(loans[i].GetDaysPastDue())
+		dpdJ, _ := strconv.Atoi(loans[j].GetDaysPastDue())
+		return dpdI < dpdJ
+	})
 
 	return loans, nil
 }

--- a/loanpro/loans.go
+++ b/loanpro/loans.go
@@ -215,6 +215,9 @@ func (c *Client) GetPastDueLoans(minDaysPastDue, limit, offset int) ([]Loan, err
 	}
 
 	loans := odataResp.D.Results
+	if len(loans) == 0 {
+		return nil, fmt.Errorf("failed to fetch loan details: Elasticsearch returned %d matches but OData returned no results", len(searchResp.D.Results))
+	}
 
 	// OData doesn't preserve Elasticsearch sort order; re-sort by daysPastDue ascending.
 	sort.Slice(loans, func(i, j int) bool {

--- a/tools/get_past_due_loans.go
+++ b/tools/get_past_due_loans.go
@@ -6,7 +6,7 @@ import "fmt"
 func GetPastDueLoansTool() Tool {
 	return Tool{
 		Name:        "get_past_due_loans",
-		Description: "Get open loans with more than a given number of days past due, sorted by days past due descending",
+		Description: "Get open loans with more than a given number of days past due, sorted by days past due ascending (most recently delinquent first)",
 		InputSchema: map[string]any{
 			"type": "object",
 			"properties": map[string]any{


### PR DESCRIPTION
## Summary
- `GetPastDueLoans` now fetches each matched loan individually via OData (`$expand=LoanSettings,LoanSetup,Customers,StatusArchive`) after the Elasticsearch filter, so `LoanSetup` is always populated and `GetActive()` returns the correct lifecycle active/inactive value
- Sorts results ascending by `daysPastDue` to surface recently delinquent loans first
- Updated tool description to reflect the new sort order

## Root cause
The Elasticsearch search endpoint (`Autopal.Search()`) does not return the `LoanSetup` nested object. With `LoanSetup` nil, `GetActive()` fell back to `"0"` for every loan — including active open loans like loan 827 (Stephen Cole).

## Test plan
- [ ] `get_past_due_loans` returns `Active: 1` for loan 827 (Stephen Cole, open/active)
- [ ] Inactive loans (e.g. loan 388, Nolan Foster) return `Active: 0`
- [ ] Results are sorted by days past due ascending
- [ ] All unit tests pass (`go test ./... -race`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Past-due loan results now sort by days past due in ascending order, showing most recently delinquent loans first.
  * Returns an empty list when no past-due matches are found to avoid confusing partial results.

* **New Features**
  * Past-due loans now include fully fetched loan details by retrieving matching records in batches for more complete results.

* **Documentation**
  * Updated tool description to reflect the new ascending sort order.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MiloCreditPlatform/loanpro-mcp-server/pull/13)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->